### PR TITLE
Update RepositoryCollaboratorEdge

### DIFF
--- a/data/graphql/ghes-3.10/schema.docs-enterprise.graphql
+++ b/data/graphql/ghes-3.10/schema.docs-enterprise.graphql
@@ -39588,6 +39588,10 @@ type RepositoryCollaboratorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
   node: User!
 
   """


### PR DESCRIPTION
description of node was missing (which led to it being not displayed at the web page)

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: 
'node' field was not displayed at /graphql/reference/objects#repositorycollaboratoredge


Closes: https://github.com/github/docs/issues/27312

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

a description is added to the field which was present in the file but was not displayed due to parsing error
standard description for most of the node fields is used: "The item at the end of the edge."


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
